### PR TITLE
change options to named params and add semver support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.vscode
 node_modules
 lib/

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ const store = createStore(reducer, null, enhancer)
 persistStore(store)
 ```
 
-In the above example `migration = createMigration(manifest, 'app')` is equivalent to the more generalized syntax:
+In the above example `migration = createMigration(manifest, {selector: 'app'})` is equivalent to the more generalized syntax:
 ```js
 // alternatively with version selector & setter
 const migration = createMigration(manifest, {

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ const store = createStore(reducer, null, enhancer)
 persistStore(store)
 ```
 
+`createMigration` takes the following form:
+```
+createMigration (manifest, versionSelector, versionSetter, isSemver = false)
+```
+
 In the above example `migration = createMigration(manifest, 'app')` is equivalent to the more generalized syntax:
 ```js
 // alternatively with version selector & setter
@@ -30,5 +35,21 @@ const migration = createMigration(
   manifest,
   (state) => state.app.version,
   (state, version) => state.app.version = version
+)
+```
+
+You can also use semver to declare your migrations:
+```js
+
+const manifest = {
+ 1: (state) => ({...state, staleReducer: undefined})
+ 2: (state) => ({...state, app: {...state.app, staleKey: undefined}})
+}
+
+const migration = createMigration(
+  manifest,
+  (state) => state.app.version,
+  (state, version) => state.app.version = version,
+  true
 )
 ```

--- a/README.md
+++ b/README.md
@@ -16,26 +16,20 @@ const manifest = {
 // reducerKey is the key of the reducer you want to store the state version in
 // in this example after migrations run `state.app.version` will equal `2`
 let reducerKey = 'app'
-const migration = createMigration(manifest, reducerKey)
+const migration = createMigration(manifest, {selector: reducerKey})
 const enhancer =  compose(migration, autoRehydrate())
 
 const store = createStore(reducer, null, enhancer)
 persistStore(store)
 ```
 
-`createMigration` takes the following form:
-```
-createMigration (manifest, versionSelector, versionSetter, isSemver = false)
-```
-
 In the above example `migration = createMigration(manifest, 'app')` is equivalent to the more generalized syntax:
 ```js
 // alternatively with version selector & setter
-const migration = createMigration(
-  manifest,
-  (state) => state.app.version,
-  (state, version) => state.app.version = version
-)
+const migration = createMigration(manifest, {
+  selector: (state) => state.app.version,
+  setter: (state, version) => state.app.version = version
+})
 ```
 
 You can also use semver to declare your migrations:
@@ -46,10 +40,8 @@ const manifest = {
  2: (state) => ({...state, app: {...state.app, staleKey: undefined}})
 }
 
-const migration = createMigration(
-  manifest,
-  (state) => state.app.version,
-  (state, version) => state.app.version = version,
-  true
-)
+const migration = createMigration(manifest, {
+  selector: 'app',
+  semver: true
+})
 ```

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ You can also use semver to declare your migrations:
 ```js
 
 const manifest = {
- 1: (state) => ({...state, staleReducer: undefined})
- 2: (state) => ({...state, app: {...state.app, staleKey: undefined}})
+ '0.0.1': (state) => ({...state, staleReducer: undefined})
+ '0.0.3-rc.1': (state) => ({...state, app: {...state.app, staleKey: undefined}})
 }
 
 const migration = createMigration(manifest, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-persist-migrate",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "migrate your redux state",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "migrate your redux state",
   "main": "lib/index.js",
   "scripts": {
-    "test": "standard",
+    "test": "mocha --require babel-register && standard",
     "build": "babel src --out-dir lib",
     "build:watch": "npm run build ./src -- -watch",
     "clean": "rimraf lib dist",
@@ -17,7 +17,10 @@
   "homepage": "https://github.com/wildlifela/redux-persist-migrate",
   "author": "rt2zz <zack@root-two.com>",
   "license": "MIT",
-  "dependencies": {},
+  "dependencies": {
+    "redux-persist": "^4.4.0",
+    "semver": "^5.3.0"
+  },
   "keywords": [
     "redux",
     "redux-persist",
@@ -32,7 +35,9 @@
     "babel-eslint": "^6.0.4",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-stage-2": "^6.5.0",
-    "babel-register": "^6.7.2",
+    "babel-register": "^6.23.0",
+    "mocha": "^3.2.0",
+    "redux": "^3.6.0",
     "rimraf": "^2.5.2",
     "standard": "^6.0.8"
   },
@@ -44,6 +49,7 @@
     "parser": "babel-eslint",
     "ignore": [
       "/lib"
-    ]
+    ],
+    "env": [ "mocha" ]
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ const processKey = (key) => {
   return int
 }
 
-export default function createMigration (manifest, versionSelector, versionSetter, isSemver) {
+export default function createMigration (manifest, versionSelector, versionSetter, isSemver = false) {
   if (typeof versionSelector === 'string') {
     let reducerKey = versionSelector
     versionSelector = (state) => state && state[reducerKey] && state[reducerKey].version

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,72 @@
+import { createStore } from 'redux'
+import { REHYDRATE } from 'redux-persist/constants'
+import assert from 'assert'
+import createMigration from '../src/index'
+
+describe('createMigration', () => {
+  it('should create a proper migration with integers', () => {
+    const manifest = {
+      3: (state) => {
+        return Object.assign(state, {test: [...state.test, 3]})
+      },
+      2: (state) => {
+        return Object.assign(state, {test: [...state.test, 2]})
+      },
+      1: (state) => {
+        return Object.assign(state, {test: [1]})
+      }
+    }
+
+    const initialState = {}
+    function test (state = initialState, action) {
+      switch (action.type) {
+        case REHYDRATE:
+          return action.payload
+      }
+      return state
+    }
+
+    const migration = createMigration(manifest, 'app', undefined)
+    const store = createStore(test, migration)
+
+    store.dispatch({
+      type: REHYDRATE,
+      payload: {}
+    })
+
+    assert.deepEqual(store.getState(), { test: [ 1, 2, 3 ], app: { version: 3 } })
+  })
+
+  it('should create a proper migration with semver', () => {
+    const manifest = {
+      '0.0.3': (state) => {
+        return Object.assign(state, {test: [...state.test, 3]})
+      },
+      '0.0.3-rc.1': (state) => {
+        return Object.assign(state, {test: [...state.test, 2]})
+      },
+      '0.0.1': (state) => {
+        return Object.assign(state, {test: [1]})
+      }
+    }
+
+    const initialState = {}
+    function test (state = initialState, action) {
+      switch (action.type) {
+        case REHYDRATE:
+          return action.payload
+      }
+      return state
+    }
+
+    const migration = createMigration(manifest, 'app', undefined, true)
+    const store = createStore(test, migration)
+
+    store.dispatch({
+      type: REHYDRATE,
+      payload: {}
+    })
+
+    assert.deepEqual(store.getState(), { test: [ 1, 2, 3 ], app: { version: '0.0.3' } })
+  })
+})

--- a/test/test.js
+++ b/test/test.js
@@ -26,7 +26,7 @@ describe('createMigration', () => {
       return state
     }
 
-    const migration = createMigration(manifest, 'app', undefined)
+    const migration = createMigration(manifest, { selector: 'app' })
     const store = createStore(test, migration)
 
     store.dispatch({
@@ -59,7 +59,7 @@ describe('createMigration', () => {
       return state
     }
 
-    const migration = createMigration(manifest, 'app', undefined, true)
+    const migration = createMigration(manifest, { selector: 'app', semver: true })
     const store = createStore(test, migration)
 
     store.dispatch({


### PR DESCRIPTION
Hi,

This is an excellent (and underappreciated IMO) package that has been really useful in our app.  We've been using semver to track our versioning and I thought it would make sense to have client side migrations to match the versions. In making the adjustment, it seemed like a nicer organization to put options as named params instead of individual arguments. Threw in some tests just to make sure it all looks good.

Don't feel obligated to pull, this is really more to open discussion. Let me know what you think.

Cheers 🍺 