### PR TITLE
Don't run migrations for new installs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,9 +37,11 @@ export default function createMigration (manifest, versionSelector, versionSette
   }
 
   const migrate = (state, version) => {
-    versionKeys
-      .filter((v) => !version || v > version)
-      .forEach((v) => { state = manifest[v](state) })
+    if (version) {
+      versionKeys
+        .filter((v) => v > version)
+        .forEach((v) => { state = manifest[v](state) })
+    }
     state = versionSetter(state, currentVersion)
     return state
   }

--- a/src/index.js
+++ b/src/index.js
@@ -22,12 +22,15 @@ export default function createMigration (manifest, versionSelector, versionSette
   }
 
   const versionKeys = Object.keys(manifest).map(processKey).sort()
-  const currentVersion = versionKeys[versionKeys.length - 1]
+  let currentVersion = versionKeys[versionKeys.length - 1]
+  if (currentVersion == null) currentVersion = -1
 
   const migrationDispatch = (next) => (action) => {
     if (action.type === REHYDRATE) {
       const incomingState = action.payload
-      const incomingVersion = versionSelector(incomingState)
+      let incomingVersion = parseInt(versionSelector(incomingState))
+      if (isNaN(incomingVersion)) incomingVersion = null
+
       if (incomingVersion !== currentVersion) {
         const migratedState = migrate(incomingState, incomingVersion)
         action.payload = migratedState
@@ -37,7 +40,7 @@ export default function createMigration (manifest, versionSelector, versionSette
   }
 
   const migrate = (state, version) => {
-    if (version) {
+    if (version != null) {
       versionKeys
         .filter((v) => v > version)
         .forEach((v) => { state = manifest[v](state) })

--- a/src/index.js
+++ b/src/index.js
@@ -26,10 +26,10 @@ export default function createMigration (manifest, versionSelector, versionSette
 
   const migrationDispatch = (next) => (action) => {
     if (action.type === REHYDRATE) {
-      let incomingState = action.payload
-      let incomingVersion = versionSelector(incomingState)
+      const incomingState = action.payload
+      const incomingVersion = versionSelector(incomingState)
       if (incomingVersion !== currentVersion) {
-        let migratedState = migrate(incomingState, incomingVersion)
+        const migratedState = migrate(incomingState, incomingVersion)
         action.payload = migratedState
       }
     }


### PR DESCRIPTION
I don't think it makes sense to run migrations when the app is first installed. The default state should already have the correct schema. So I added a check to skip migrations if `version` is `undefined`.