### PR TITLE
Fix version sort

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ export default function createMigration (manifest, versionSelector, versionSette
     }
   }
 
-  const versionKeys = Object.keys(manifest).map(processKey).sort()
+  const versionKeys = Object.keys(manifest).map(processKey).sort((a, b) => a - b)
   const currentVersion = versionKeys[versionKeys.length - 1]
 
   const migrationDispatch = (next) => (action) => {


### PR DESCRIPTION
JavaScript array sort by default sorts by lexicographical order, so `10` comes before `2`.

For example:

```
> var manifest = { 0: null, 1: null, 2: null, 10: null }
undefined
> Object.keys(manifest).map(key => parseInt(key)).sort()
[ 0, 1, 10, 2 ]
```