### PR TITLE
Enable initial migrations, clarify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,26 +4,38 @@ Migrate redux state between versions with redux-persist.
 
 #### Usage
 ```js
-import { compose, createStore } from 'redux'
+import { compose, createStore, combineReducers } from 'redux'
 import { persistStore, autoRehydrate } from 'redux-persist'
 import createMigration from 'redux-persist-migrate'
 
+// VERSION_REDUCER_KEY is the key of the reducer you want to store the state version in.
+// You _must_ create this reducer, redux-persist-migrate will not create it for you.
+// In this example after migrations run, `state.app.version` will equal `2`
+const VERSION_REDUCER_KEY = 'app'
+
+// This is a list of changes to make to the state being rehydrated.
+// The keys must be integers, and migrations will be performed in ascending key order.
+// Note: blacklisted reducers will not be present in this state.
 const manifest = {
- 1: (state) => ({...state, staleReducer: undefined})
- 2: (state) => ({...state, app: {...state.app, staleKey: undefined}})
+  1: (state) => ({...state, staleReducer: undefined})
+  2: (state) => ({...state, app: {...state.app, staleKey: undefined}})
 }
 
-// reducerKey is the key of the reducer you want to store the state version in
-// in this example after migrations run `state.app.version` will equal `2`
-let reducerKey = 'app'
-const migration = createMigration(manifest, reducerKey)
+const migration = createMigration(manifest, VERSION_REDUCER_KEY)
 const enhancer =  compose(migration, autoRehydrate())
+
+const reducer = combineReducers({
+    [VERSION_REDUCER_KEY]: (state = {}) => state, // This reducer will be used to store the version
+    otherReducer1,
+    otherReducer2,
+    // ...
+})
 
 const store = createStore(reducer, null, enhancer)
 persistStore(store)
 ```
 
-In the above example `migration = createMigration(manifest, 'app')` is equivalent to the more generalized syntax:
+In the above example `migration = createMigration(manifest, VERSION_REDUCER_KEY)` is equivalent to the more generalized syntax:
 ```js
 // alternatively with version selector & setter
 const migration = createMigration(

--- a/src/index.js
+++ b/src/index.js
@@ -40,11 +40,10 @@ export default function createMigration (manifest, versionSelector, versionSette
   }
 
   const migrate = (state, version) => {
-    if (version != null) {
-      versionKeys
-        .filter((v) => v > version)
-        .forEach((v) => { state = manifest[v](state) })
-    }
+    versionKeys
+      .filter((v) => v > version || version === null)
+      .forEach((v) => { state = manifest[v](state) })
+
     state = versionSetter(state, currentVersion)
     return state
   }

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ export default function createMigration (manifest, versionSelector, versionSette
 
   const versionKeys = Object.keys(manifest).map(processKey).sort((a, b) => a - b)
   let currentVersion = versionKeys[versionKeys.length - 1]
-  if (!currentVersion) currentVersion = -1
+  if (!currentVersion && currentVersion !== 0) currentVersion = -1
 
   const migrationDispatch = (next) => (action) => {
     if (action.type === REHYDRATE) {


### PR DESCRIPTION
I had a bit of trouble getting started with this library, and this PR attempts to make it a bit easier for others.  It does a few things:

- Allow a version key of `0`.  Previously,  `0` was being turned into `-1`.  I don't think this was intentional.
- Perform migrations when the user does not have a previously-stored version (i.e. the first time the app is deployed with `redux-persist-migrate`.  This is a fairly substantial change, and I put some notes in the commit message.  I'm happy to discuss the pros/cons further.  
- Update the README to clarify that you need to have an existing reducer to store the `version` in.