### PR TITLE
Immutable.js support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 node_modules
-lib/

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,121 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
+exports.default = createMigration;
+
+var _constants = require('redux-persist/constants');
+
+var _immutable = require('immutable');
+
+var _immutable2 = _interopRequireDefault(_immutable);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+var processKey = function processKey(key) {
+  var int = parseInt(key);
+  if (isNaN(int)) throw new Error('redux-persist-migrate: migrations must be keyed with integer values');
+  return int;
+};
+
+var isKeyValid = function isKeyValid(key) {
+  if (['undefined', 'object'].indexOf(typeof key === 'undefined' ? 'undefined' : _typeof(key)) === -1) {
+    console.error('redux-persist-migrate: state for versionSetter key must be an object or undefined');
+    return false;
+  }
+  return true;
+};
+
+var getVersionSelector = function getVersionSelector(reducerKey) {
+  return function (state) {
+    var reduced = null;
+    if (_immutable2.default.Map.isMap(state)) {
+      reduced = state.get(reducerKey, null);
+    } else {
+      reduced = state[reducerKey];
+    }
+    if (!reduced) {
+      return null;
+    } else if (_immutable2.default.Map.isMap(reduced)) {
+      return reduced.get('version');
+    }
+    return reduced.version;
+  };
+};
+
+var getVersionSetter = function getVersionSetter(reducerKey) {
+  return function (state, version) {
+    var reduced = _immutable2.default.Map.isMap(state) ? state.get(reducerKey) : state[reducerKey];
+    if (!isKeyValid(reduced)) {
+      return state;
+    }
+    if (_immutable2.default.Map.isMap(reduced)) {
+      reduced = reduced.set('version', version);
+    } else {
+      reduced = _extends({}, reduced, { version: version });
+    }
+    if (_immutable2.default.Map.isMap(state)) {
+      return state.set(reducerKey, reduced);
+    }
+    return _extends({}, state, _defineProperty({}, reducerKey, reduced));
+  };
+};
+
+function createMigration(manifest, versionSelector, versionSetter) {
+  if (typeof versionSelector === 'string') {
+    var reducerKey = versionSelector;
+    versionSelector = getVersionSelector(reducerKey);
+    versionSetter = getVersionSetter(reducerKey);
+  }
+
+  var versionKeys = Object.keys(manifest).map(processKey).sort(function (a, b) {
+    return a - b;
+  });
+  var currentVersion = versionKeys[versionKeys.length - 1];
+  if (!currentVersion) currentVersion = -1;
+
+  var migrationDispatch = function migrationDispatch(next) {
+    return function (action) {
+      if (action.type === _constants.REHYDRATE) {
+        var incomingState = action.payload;
+        var incomingVersion = parseInt(versionSelector(incomingState));
+        if (isNaN(incomingVersion)) incomingVersion = null;
+
+        if (incomingVersion !== currentVersion) {
+          var migratedState = migrate(incomingState, incomingVersion);
+          action.payload = migratedState;
+        }
+      }
+      return next(action);
+    };
+  };
+
+  var migrate = function migrate(state, version) {
+    if (version != null) {
+      versionKeys.filter(function (v) {
+        return v > version;
+      }).forEach(function (v) {
+        state = manifest[v](state);
+      });
+    }
+    state = versionSetter(state, currentVersion);
+    return state;
+  };
+
+  return function (next) {
+    return function (reducer, initialState, enhancer) {
+      var store = next(reducer, initialState, enhancer);
+      return _extends({}, store, {
+        dispatch: migrationDispatch(store.dispatch)
+      });
+    };
+  };
+}

--- a/package.json
+++ b/package.json
@@ -17,16 +17,16 @@
   "homepage": "https://github.com/wildlifela/redux-persist-migrate",
   "author": "rt2zz <zack@root-two.com>",
   "license": "MIT",
-  "dependencies": {},
+  "dependencies": {
+    "immutable": "^3.8.1",
+    "redux-persist": ">=3.0.0"
+  },
   "keywords": [
     "redux",
     "redux-persist",
     "redux-persist-migrate",
     "redux-migrate"
   ],
-  "peerDependencies": {
-    "redux-persist": ">=3.0.0"
-  },
   "devDependencies": {
     "babel-cli": "^6.7.7",
     "babel-eslint": "^6.0.4",

--- a/src/index.js
+++ b/src/index.js
@@ -1,24 +1,62 @@
 import { REHYDRATE } from 'redux-persist/constants'
+import Immutable from 'immutable'
 
 const processKey = (key) => {
-  let int = parseInt(key)
+  const int = parseInt(key)
   if (isNaN(int)) throw new Error('redux-persist-migrate: migrations must be keyed with integer values')
   return int
 }
 
-export default function createMigration (manifest, versionSelector, versionSetter) {
-  if (typeof versionSelector === 'string') {
-    let reducerKey = versionSelector
-    versionSelector = (state) => state && state[reducerKey] && state[reducerKey].version
-    versionSetter = (state, version) => {
-      if (['undefined', 'object'].indexOf(typeof state[reducerKey]) === -1) {
-        console.error('redux-persist-migrate: state for versionSetter key must be an object or undefined')
+const isKeyValid = (key) => {
+  if (['undefined', 'object'].indexOf(typeof key) === -1) {
+    console.error('redux-persist-migrate: state for versionSetter key must be an object or undefined')
+    return false
+  }
+  return true
+}
+
+const getVersionSelector = (reducerKey) => {
+  return (state) => {
+    if (Immutable.Map.isMap(state)) {
+      return state.getIn([reducerKey, 'version'], null)
+    }
+    if (reducerKey in state && 'version' in state[reducerKey]) {
+      return state[reducerKey].version
+    }
+    return null
+  }
+}
+
+const getVersionSetter = (reducerKey) => {
+  return (state, version) => {
+    if (Immutable.Map.isMap(state)) {
+      const reduced = state.get(reducerKey)
+      if (!isKeyValid(reduced)) {
         return state
       }
-      state[reducerKey] = state[reducerKey] || {}
-      state[reducerKey].version = version
+      if (!state.has(reducerKey)) {
+        state.set(reducerKey, Immutable.Map())
+      }
+      return state.setIn([reducerKey, 'version'], version)
+    }
+    if (!isKeyValid(state[reducerKey])) {
       return state
     }
+    return {
+      ...state,
+      [reducerKey]: {
+        ...state[reducerKey],
+        version: version
+      }
+    }
+  }
+}
+
+export default function createMigration (manifest, versionSelector, versionSetter) {
+  if (typeof versionSelector === 'string') {
+    const reducerKey = versionSelector
+    versionSelector = getVersionSelector(reducerKey)
+    versionSetter = getVersionSetter(reducerKey)
   }
 
   const versionKeys = Object.keys(manifest).map(processKey).sort((a, b) => a - b)
@@ -43,14 +81,16 @@ export default function createMigration (manifest, versionSelector, versionSette
     if (version != null) {
       versionKeys
         .filter((v) => v > version)
-        .forEach((v) => { state = manifest[v](state) })
+        .forEach((v) => {
+          state = manifest[v](state)
+        })
     }
     state = versionSetter(state, currentVersion)
     return state
   }
 
   return (next) => (reducer, initialState, enhancer) => {
-    var store = next(reducer, initialState, enhancer)
+    const store = next(reducer, initialState, enhancer)
     return {
       ...store,
       dispatch: migrationDispatch(store.dispatch)

--- a/src/index.js
+++ b/src/index.js
@@ -17,13 +17,18 @@ const isKeyValid = (key) => {
 
 const getVersionSelector = (reducerKey) => {
   return (state) => {
+    let reduced = null
     if (Immutable.Map.isMap(state)) {
-      return state.getIn([reducerKey, 'version'], null)
+      reduced = state.get(reducerKey, null)
+    } else {
+      reduced = state[reducerKey]
     }
-    if (reducerKey in state && 'version' in state[reducerKey]) {
-      return state[reducerKey].version
+    if (!reduced) {
+      return null
+    } else if (Immutable.Map.isMap(reduced)) {
+      return reduced.get('version')
     }
-    return null
+    return reduced.version
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -29,25 +29,21 @@ const getVersionSelector = (reducerKey) => {
 
 const getVersionSetter = (reducerKey) => {
   return (state, version) => {
-    if (Immutable.Map.isMap(state)) {
-      const reduced = state.get(reducerKey)
-      if (!isKeyValid(reduced)) {
-        return state
-      }
-      if (!state.has(reducerKey)) {
-        state.set(reducerKey, Immutable.Map())
-      }
-      return state.setIn([reducerKey, 'version'], version)
-    }
-    if (!isKeyValid(state[reducerKey])) {
+    let reduced = Immutable.Map.isMap(state) ? state.get(reducerKey) : state[reducerKey]
+    if (!isKeyValid(reduced)) {
       return state
+    }
+    if (Immutable.Map.isMap(reduced)) {
+      reduced = reduced.set('version', version)
+    } else {
+      reduced = {...reduced, version: version}
+    }
+    if (Immutable.Map.isMap(state)) {
+      return state.set(reducerKey, reduced)
     }
     return {
       ...state,
-      [reducerKey]: {
-        ...state[reducerKey],
-        version: version
-      }
+      [reducerKey]: reduced
     }
   }
 }


### PR DESCRIPTION
Add support for `Immutable.js`.
Also makes non `Immutable.js` state modifications immutable (with spread operator) (see #4).

With this, I can migrate a basic store to an `Immutable.js` one 

```javascript
import createMigration from 'redux-persist-migrate';
import Immutable from 'immutable';

// these keys won't be persisted
export const blacklist = [
  'dummy'
];

function fromJSGreedy(js) {
  if (typeof js !== 'object' || js === null) {
    return js;
  }
  if (Immutable.Iterable.isIterable(js)) {
    return js.map(fromJSGreedy);
  }
  if (Array.isArray(js)) {
    return Immutable.Seq(js).map(fromJSGreedy).toList();
  }
  return Immutable.Seq(js).map(fromJSGreedy).toMap();
}

export const manifest = {
  1: state => fromJSGreedy(state).toObject() // payload must be an object
};

const reducerKey = 'app';
export const migration = createMigration(manifest, reducerKey);
```