### PR TITLE
Corrected versionSetter in the example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ In the above example `migration = createMigration(manifest, 'app')` is equivalen
 const migration = createMigration(
   manifest,
   (state) => state.app.version,
-  (state, version) => state.app.version = version
+  (state, version) => {
+    return { ...state, app: { ...state.app, version: version } }
+  }
 )
 ```


### PR DESCRIPTION
Hi, 
thank you all for this library, saved us lot of work!

I have to use custom key in our reducer to store the version of the state and found out, that the `versionSetter` does not work with the example code.
The `migrate` function expects that the `versionSetter` returns the updated state.

Cheers!
